### PR TITLE
Add debug

### DIFF
--- a/tests/cases/docker-compose-test.yaml
+++ b/tests/cases/docker-compose-test.yaml
@@ -21,6 +21,9 @@ services:
       retries: 5
     networks:
       - *network-common
+    extra_hosts:
+      - host.internal:${LOCAL_HOST_IP}
+
   tendermint-chain1:
     container_name: tendermint-chain1
     image: tendermint-chain1:${TAG}
@@ -36,6 +39,9 @@ services:
       retries: 5
     networks:
       - *network-common
+    extra_hosts:
+      - host.internal:${LOCAL_HOST_IP}
+
   tendermint-proxy0:
     container_name: tendermint-proxy0
     image: tendermint-proxy0:${TAG}
@@ -51,3 +57,5 @@ services:
       retries: 5
     networks:
       - *network-common
+    extra_hosts:
+      - host.internal:${LOCAL_HOST_IP}

--- a/tests/cases/tm2tm-sym/Makefile
+++ b/tests/cases/tm2tm-sym/Makefile
@@ -1,8 +1,16 @@
 include ../../docker.mk
 
+ifeq  ($(shell uname),Darwin)
+IP_CMD?=ifconfig en0
+else
+IP_CMD?=ip -4 addr show docker0
+endif
+
+LOCAL_HOST_IP ?= $(shell $(IP_CMD) | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1' | awk '{print $1}')
+
 .PHONY: network
 network:
-	TAG=${DOCKER_TAG} $(DOCKER_COMPOSE) \
+	LOCAL_HOST_IP=$(LOCAL_HOST_IP) TAG=${DOCKER_TAG} $(DOCKER_COMPOSE) \
 		-f ../docker-compose-test.yaml \
 		up -d \
 		tendermint-chain0 tendermint-chain1 tendermint-proxy0
@@ -16,6 +24,6 @@ test:
 
 .PHONY: network-down
 network-down:
-	TAG=${DOCKER_TAG} $(DOCKER_COMPOSE) \
+	LOCAL_HOST_IP=$(LOCAL_HOST_IP) TAG=${DOCKER_TAG} $(DOCKER_COMPOSE) \
 		-f ../docker-compose-test.yaml \
 		down --volume --remove-orphans

--- a/tests/cases/tm2tm-sym/scripts/fixture
+++ b/tests/cases/tm2tm-sym/scripts/fixture
@@ -15,6 +15,10 @@ mkdir -p ${FIXTURES_DIR}/tendermint/proxy0
 set -x
 
 ## copy tendermint's node mnemonic from node container
-${DOCKER} cp tendermint-chain0:/root/data/ibc0/key_seed.json  ${FIXTURES_DIR}/tendermint/ibc0/key_seed.json
+
+# TODO: For Debug
+#${DOCKER} cp tendermint-chain0:/root/data/ibc0/key_seed.json  ${FIXTURES_DIR}/tendermint/ibc0/key_seed.json
+cp ../../chains/tendermint/data/ibc0/key_seed.json  ${FIXTURES_DIR}/tendermint/ibc0/key_seed.json
+
 ${DOCKER} cp tendermint-chain1:/root/data/ibc1/key_seed.json  ${FIXTURES_DIR}/tendermint/ibc1/key_seed.json
 ${DOCKER} cp tendermint-proxy0:/root/data/proxy0/key_seed.json  ${FIXTURES_DIR}/tendermint/proxy0/key_seed.json

--- a/tests/chains/tendermint/Dockerfile
+++ b/tests/chains/tendermint/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /root
 
 COPY ./ ./
 
-RUN go build -mod readonly -o /root/build/simd ./simapp/simd
+RUN go build -mod=vendor -o /root/build/simd ./simapp/simd
 
 FROM alpine:${ALPINE_VER} AS initializer
 

--- a/tests/chains/tendermint/Makefile
+++ b/tests/chains/tendermint/Makefile
@@ -6,6 +6,7 @@ build:
 
 .PHONY: docker-images
 docker-images:
+	go mod vendor
 	$(DOCKER_BUILD) \
 		--build-arg CHAINID=ibc0 \
 		--tag $(DOCKER_REPO)tendermint-chain0:$(DOCKER_TAG) .


### PR DESCRIPTION
デバッグの設定
![スクリーンショット 2022-01-20 17 28 39](https://user-images.githubusercontent.com/7260243/150301449-72b65200-cf7a-4604-b93a-133c3706b07e.png)

### 手順
- 開始
```
(in tm2tm-sym)
$ make network
$ docker cp tendermint-chain0:/root/data ../../chains/tendermint/data
$ docker-compose -f ../docker-compose-test.yaml rm -fsv tendermint-chain0
```

その後、添付画像を参考にIntellijからデバッグモードでtendermint-chain0を起動

- 終了
```
(in tm2tm-sym)
$ make network-down
$ rm -rf ../../chains/tendermint/data
```

debugモードで起動したtendermint-chain0を終了

### 補足
--grpc-webが9091ポートを使って他のtendermintと衝突するので適当に回避